### PR TITLE
Remove import version numbers

### DIFF
--- a/Cosmic Astrology Landing Page/components/ui/context-menu.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/context-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as ContextMenuPrimitive from "@radix-ui/react-context-menu@2.2.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/dialog.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as DialogPrimitive from "@radix-ui/react-dialog@1.1.6";
-import { XIcon } from "lucide-react@0.487.0";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/drawer.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul@1.1.2";
+import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/dropdown-menu.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu@2.1.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/form.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label@2.1.2";
-import { Slot } from "@radix-ui/react-slot@1.1.2";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import {
   Controller,
   FormProvider,
@@ -11,7 +11,7 @@ import {
   type ControllerProps,
   type FieldPath,
   type FieldValues,
-} from "react-hook-form@7.55.0";
+} from "react-hook-form";
 
 import { cn } from "./utils";
 import { Label } from "./label";

--- a/Cosmic Astrology Landing Page/components/ui/hover-card.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/hover-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as HoverCardPrimitive from "@radix-ui/react-hover-card@1.1.6";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/input-otp.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/input-otp.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { OTPInput, OTPInputContext } from "input-otp@1.4.2";
-import { MinusIcon } from "lucide-react@0.487.0";
+import { OTPInput, OTPInputContext } from "input-otp";
+import { MinusIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/label.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/label.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label@2.1.2";
+import * as LabelPrimitive from "@radix-ui/react-label";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/menubar.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/menubar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as MenubarPrimitive from "@radix-ui/react-menubar@1.1.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import * as MenubarPrimitive from "@radix-ui/react-menubar";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/navigation-menu.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu@1.2.5";
-import { cva } from "class-variance-authority@0.7.1";
-import { ChevronDownIcon } from "lucide-react@0.487.0";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/pagination.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/pagination.tsx
@@ -3,7 +3,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
-} from "lucide-react@0.487.0";
+} from "lucide-react";
 
 import { cn } from "./utils";
 import { Button, buttonVariants } from "./button";

--- a/Cosmic Astrology Landing Page/components/ui/popover.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as PopoverPrimitive from "@radix-ui/react-popover@1.1.6";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/progress.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/progress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as ProgressPrimitive from "@radix-ui/react-progress@1.1.2";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/radio-group.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/radio-group.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group@1.2.3";
-import { CircleIcon } from "lucide-react@0.487.0";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/resizable.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/resizable.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { GripVerticalIcon } from "lucide-react@0.487.0";
-import * as ResizablePrimitive from "react-resizable-panels@2.1.7";
+import { GripVerticalIcon } from "lucide-react";
+import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/scroll-area.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/scroll-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area@1.2.3";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/select.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/select.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import * as React from "react";
-import * as SelectPrimitive from "@radix-ui/react-select@2.1.6";
+import * as SelectPrimitive from "@radix-ui/react-select";
 import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-} from "lucide-react@0.487.0";
+} from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/separator.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as SeparatorPrimitive from "@radix-ui/react-separator@1.1.2";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/sheet.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/sheet.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as SheetPrimitive from "@radix-ui/react-dialog@1.1.6";
-import { XIcon } from "lucide-react@0.487.0";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/sidebar.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/sidebar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot@1.1.2";
-import { VariantProps, cva } from "class-variance-authority@0.7.1";
-import { PanelLeftIcon } from "lucide-react@0.487.0";
+import { Slot } from "@radix-ui/react-slot";
+import { VariantProps, cva } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
 
 import { useIsMobile } from "./use-mobile";
 import { cn } from "./utils";

--- a/Cosmic Astrology Landing Page/components/ui/slider.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/slider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as SliderPrimitive from "@radix-ui/react-slider@1.2.3";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/sonner.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useTheme } from "next-themes@0.4.6";
-import { Toaster as Sonner, ToasterProps } from "sonner@2.0.3";
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();

--- a/Cosmic Astrology Landing Page/components/ui/switch.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as SwitchPrimitive from "@radix-ui/react-switch@1.1.3";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/tabs.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as TabsPrimitive from "@radix-ui/react-tabs@1.1.3";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/toggle-group.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/toggle-group.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group@1.1.2";
-import { type VariantProps } from "class-variance-authority@0.7.1";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
 import { toggleVariants } from "./toggle";

--- a/Cosmic Astrology Landing Page/components/ui/toggle.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/toggle.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import * as TogglePrimitive from "@radix-ui/react-toggle@1.1.2";
-import { cva, type VariantProps } from "class-variance-authority@0.7.1";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "./utils";
 

--- a/Cosmic Astrology Landing Page/components/ui/tooltip.tsx
+++ b/Cosmic Astrology Landing Page/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip@1.1.8";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import { cn } from "./utils";
 


### PR DESCRIPTION
Remove version numbers from package imports to resolve module resolution errors.

The presence of version numbers in import paths was causing module resolution failures and "red lines" in the IDE.